### PR TITLE
feat: add FileHelper class for retrying file access operations

### DIFF
--- a/src/Devantler.Commons.Utils/FileUtils.cs
+++ b/src/Devantler.Commons.Utils/FileUtils.cs
@@ -32,10 +32,6 @@ public static class FileHelper
         // Wait and retry if the file is locked.
         await Task.Delay(100, linkedCts.Token).ConfigureAwait(false);
       }
-      catch (Exception)
-      {
-        throw;
-      }
     }
   }
 }

--- a/src/Devantler.Commons.Utils/FileUtils.cs
+++ b/src/Devantler.Commons.Utils/FileUtils.cs
@@ -14,7 +14,7 @@ public static class FileHelper
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
   /// <exception cref="TimeoutException"></exception>
-  public static async Task RetryFileAccessAsync(Func<Task> fileAccessAction, int timeoutInSeconds = 5, CancellationToken cancellationToken)
+  public static async Task RetryFileAccessAsync(Func<Task> fileAccessAction, int timeoutInSeconds = 5, CancellationToken cancellationToken = default)
   {
     ArgumentNullException.ThrowIfNull(fileAccessAction);
     using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutInSeconds));
@@ -29,11 +29,12 @@ public static class FileHelper
       }
       catch (IOException)
       {
-        if (timeoutCts.Token.IsCancellationRequested)
-          throw new TimeoutException($"Failed to access the file within the timeout of {timeoutInSeconds} seconds.");
-
         // Wait and retry if the file is locked.
         await Task.Delay(100, linkedCts.Token).ConfigureAwait(false);
+      }
+      catch (Exception)
+      {
+        throw;
       }
     }
   }

--- a/src/Devantler.Commons.Utils/FileUtils.cs
+++ b/src/Devantler.Commons.Utils/FileUtils.cs
@@ -1,0 +1,40 @@
+namespace Devantler.Commons.Utils;
+
+
+/// <summary>
+/// Helper class for file access operations. 
+/// </summary>
+public static class FileHelper
+{
+  /// <summary>
+  /// Helper method to retry file access operations with a timeout.
+  /// </summary>
+  /// <param name="fileAccessAction"></param>
+  /// <param name="timeoutInSeconds"></param>
+  /// <param name="cancellationToken"></param>
+  /// <returns></returns>
+  /// <exception cref="TimeoutException"></exception>
+  public static async Task RetryFileAccessAsync(Func<Task> fileAccessAction, int timeoutInSeconds = 5, CancellationToken cancellationToken)
+  {
+    ArgumentNullException.ThrowIfNull(fileAccessAction);
+    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutInSeconds));
+    using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+    while (true)
+    {
+      try
+      {
+        await fileAccessAction().ConfigureAwait(false);
+        break; // Exit the loop if the file access succeeds.
+      }
+      catch (IOException)
+      {
+        if (timeoutCts.Token.IsCancellationRequested)
+          throw new TimeoutException($"Failed to access the file within the timeout of {timeoutInSeconds} seconds.");
+
+        // Wait and retry if the file is locked.
+        await Task.Delay(100, linkedCts.Token).ConfigureAwait(false);
+      }
+    }
+  }
+}

--- a/tests/Devantler.Commons.Utils.Tests/FileHelperTests.cs
+++ b/tests/Devantler.Commons.Utils.Tests/FileHelperTests.cs
@@ -1,0 +1,95 @@
+﻿namespace Devantler.Commons.Utils.Tests;
+
+/// <summary>
+/// Unit tests for the FileHelper class.
+/// </summary>
+public class FileHelperTests
+{
+  /// <summary>
+  /// Tests the RetryFileAccessAsync method for successful file access.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task RetryFileAccessAsync_SuccessfulFileAccess_DoesNotThrow()
+  {
+    // Arrange
+    var fileAccessAction = new Func<Task>(() => Task.CompletedTask);
+
+    // Act & Assert
+    await FileHelper.RetryFileAccessAsync(fileAccessAction);
+  }
+
+  /// <summary>
+  /// Tests the RetryFileAccessAsync method for file access that throws an IOException.
+  /// </summary>
+  /// <returns></returns>
+  /// <exception cref="IOException"></exception>
+  [Fact]
+  public async Task RetryFileAccessAsync_FileAccessThrowsIOException_RetriesUntilSuccess()
+  {
+    // Arrange
+    int attempt = 0;
+    var fileAccessAction = new Func<Task>(() =>
+    {
+      attempt++;
+      if (attempt < 3)
+        throw new IOException("File is locked.");
+      return Task.CompletedTask;
+    });
+
+    // Act
+    await FileHelper.RetryFileAccessAsync(fileAccessAction);
+
+    // Assert
+    Assert.Equal(3, attempt);
+  }
+
+  /// <summary>
+  /// Tests the RetryFileAccessAsync method for file access that times out.
+  /// </summary>
+  /// <returns></returns>
+  /// <exception cref="IOException"></exception>
+  [Fact]
+  public async Task RetryFileAccessAsync_FileAccessTimeout_ThrowsTaskCanceledException()
+  {
+    // Arrange
+    var fileAccessAction = new Func<Task>(() => throw new IOException("File is locked."));
+    int timeoutInSeconds = 1;
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+      await FileHelper.RetryFileAccessAsync(fileAccessAction, timeoutInSeconds).ConfigureAwait(false));
+    Assert.Contains($"A task was canceled.", exception.Message, StringComparison.Ordinal);
+  }
+
+  /// <summary>
+  /// Tests the RetryFileAccessAsync method for file access that times out.
+  /// </summary>
+  /// <returns></returns>
+  /// <exception cref="IOException"></exception>
+  [Fact]
+  public async Task RetryFileAccessAsync_CancellationRequested_ThrowsTaskCanceledException()
+  {
+    // Arrange
+    var fileAccessAction = new Func<Task>(() => throw new IOException("File is locked."));
+    using var cancellationTokenSource = new CancellationTokenSource();
+    await cancellationTokenSource.CancelAsync();
+
+    // Act & Assert
+    var exception = await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+      await FileHelper.RetryFileAccessAsync(fileAccessAction, 20, cancellationToken: cancellationTokenSource.Token).ConfigureAwait(false));
+    Assert.Contains($"A task was canceled.", exception.Message, StringComparison.Ordinal);
+  }
+
+  /// <summary>
+  /// Tests the RetryFileAccessAsync method with a null file access action.
+  /// </summary>
+  /// <returns></returns>
+  [Fact]
+  public async Task RetryFileAccessAsync_NullFileAccessAction_ThrowsArgumentNullException()
+  {
+    // Act & Assert
+    await Assert.ThrowsAsync<ArgumentNullException>(() =>
+      FileHelper.RetryFileAccessAsync(null!));
+  }
+}


### PR DESCRIPTION
Introduce a FileHelper class that provides a method to retry file access operations with a specified timeout, enhancing robustness in file handling scenarios.